### PR TITLE
Environment variable support

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,10 +13,6 @@ on:
     branches:
       - main
       - development
-  pull_request:
-    branches:
-      - main
-      - development
 
 env:
   REGISTRY: ghcr.io

--- a/src/main/java/com/mealtiger/backend/configuration/ConfigLoader.java
+++ b/src/main/java/com/mealtiger/backend/configuration/ConfigLoader.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.configuration;
 
+import com.mealtiger.backend.configuration.annotations.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.DumperOptions;

--- a/src/main/java/com/mealtiger/backend/configuration/Configurator.java
+++ b/src/main/java/com/mealtiger/backend/configuration/Configurator.java
@@ -1,5 +1,7 @@
 package com.mealtiger.backend.configuration;
 
+import com.mealtiger.backend.configuration.annotations.Config;
+import com.mealtiger.backend.configuration.annotations.ConfigNode;
 import com.mealtiger.backend.configuration.exceptions.NoSuchConfigException;
 import com.mealtiger.backend.configuration.exceptions.NoSuchPropertyException;
 import org.slf4j.Logger;

--- a/src/main/java/com/mealtiger/backend/configuration/Configurator.java
+++ b/src/main/java/com/mealtiger/backend/configuration/Configurator.java
@@ -111,10 +111,37 @@ public class Configurator {
 
         for (Method method : configMethods) {
             if (method.isAnnotationPresent(ConfigNode.class) && method.getAnnotation(ConfigNode.class).name().equals(propertyDescriptor)) {
-                try {
-                    returnValue = method.invoke(config);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new RuntimeException("Error when trying to retrieve config property " + property + "!");
+                String envKey = method.getAnnotation(ConfigNode.class).envKey();
+                String envValue = envKey.length() != 0 ? System.getenv(envKey) : "";
+
+                if (envKey.length() != 0) {
+                    Class<?> returnType = method.getReturnType();
+
+                    try {
+                        if (returnType == String.class) {
+                            returnValue = envValue;
+                        } else if (returnType == Integer.class) {
+                            returnValue = Integer.valueOf(envValue);
+                        } else if (returnType == Boolean.class) {
+                            switch (envValue.toLowerCase()) {
+                                case "true" -> returnValue = Boolean.TRUE;
+                                case "false" -> returnValue = Boolean.FALSE;
+                                default -> throw new IllegalArgumentException();
+                            }
+                        } else if (returnType == Double.class) {
+                            returnValue = Double.valueOf(envValue);
+                        }
+                    } catch (Exception e) {
+                        log.error("Environment variable {} cannot be parsed. Proceeding with config value!", envKey);
+                    }
+                }
+
+                if (returnValue == null) {
+                    try {
+                        returnValue = method.invoke(config);
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException("Error when trying to retrieve config property " + property + "!");
+                    }
                 }
             }
         }

--- a/src/main/java/com/mealtiger/backend/configuration/annotations/Config.java
+++ b/src/main/java/com/mealtiger/backend/configuration/annotations/Config.java
@@ -1,4 +1,4 @@
-package com.mealtiger.backend.configuration;
+package com.mealtiger.backend.configuration.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/mealtiger/backend/configuration/annotations/ConfigNode.java
+++ b/src/main/java/com/mealtiger/backend/configuration/annotations/ConfigNode.java
@@ -1,4 +1,4 @@
-package com.mealtiger.backend.configuration;
+package com.mealtiger.backend.configuration.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -18,4 +18,9 @@ public @interface ConfigNode {
      * Represents a property from a config file. Example: Database.mongoDBURL
      */
     String name();
+
+    /**
+     * If changed an environment variable of this name will override the config setting
+     */
+    String envKey() default "";
 }

--- a/src/main/java/com/mealtiger/backend/configuration/configs/MainConfig.java
+++ b/src/main/java/com/mealtiger/backend/configuration/configs/MainConfig.java
@@ -1,7 +1,7 @@
 package com.mealtiger.backend.configuration.configs;
 
-import com.mealtiger.backend.configuration.Config;
-import com.mealtiger.backend.configuration.ConfigNode;
+import com.mealtiger.backend.configuration.annotations.Config;
+import com.mealtiger.backend.configuration.annotations.ConfigNode;
 import org.springframework.boot.logging.LogLevel;
 
 /**

--- a/src/main/java/com/mealtiger/backend/configuration/configs/MainConfig.java
+++ b/src/main/java/com/mealtiger/backend/configuration/configs/MainConfig.java
@@ -21,19 +21,19 @@ public class MainConfig {
         logging = new Logging();
     }
 
-    @ConfigNode(name = "Database.mongoDBURL")
+    @ConfigNode(name = "Database.mongoDBURL", envKey = "DBURL")
     @SuppressWarnings("unused")
     public String getMongoConnectionString() {
         return database.mongoDBURL;
     }
 
-    @ConfigNode(name = "Database.databaseName")
+    @ConfigNode(name = "Database.databaseName", envKey = "DB")
     @SuppressWarnings("unused")
     public String getMongoDatabase() {
         return database.database;
     }
 
-    @ConfigNode(name = "Logging.logLevel")
+    @ConfigNode(name = "Logging.logLevel", envKey = "LOGLEVEL")
     @SuppressWarnings("unused")
     public String getLogLevel() {
         return logging.logLevel;

--- a/src/test/java/com/mealtiger/backend/configuration/configs/TestConfig.java
+++ b/src/test/java/com/mealtiger/backend/configuration/configs/TestConfig.java
@@ -1,7 +1,7 @@
 package com.mealtiger.backend.configuration.configs;
 
-import com.mealtiger.backend.configuration.Config;
-import com.mealtiger.backend.configuration.ConfigNode;
+import com.mealtiger.backend.configuration.annotations.Config;
+import com.mealtiger.backend.configuration.annotations.ConfigNode;
 
 @Config(name = "Test", configPath = "test.yml")
 public class TestConfig {


### PR DESCRIPTION
This resolves issue #18

Now, the annotation ConfigNode supports the addition of a environment variable key. Its value overrides the corresponding config value.

Sadly, this functionality cannot be unit tested due to the fact that environment variables can't be changed at runtime.