### PR TITLE
Implement authentication via JWT through OIDC Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>2.7.6</version>
         <relativePath/>
     </parent>
     <groupId>com.meal-tiger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,18 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
 
         <!-- SnakeYAML for YAML-(De-)Serialization -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,19 @@
     </dependencies>
     <build>
         <plugins>
+            <!-- maven surefire plugin for unit testing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+            <!-- maven failsafe plugin for integration testing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+            <!-- spring boot maven plugin -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/com/mealtiger/backend/BackendApplication.java
+++ b/src/main/java/com/mealtiger/backend/BackendApplication.java
@@ -5,7 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -51,6 +50,7 @@ public class BackendApplication implements CommandLineRunner {
                 String[] allowedOriginsArray = allowedOrigins.split(",");
 
                 registry.addMapping("/recipes").allowedOrigins(allowedOriginsArray);
+                registry.addMapping("/recipes/**").allowedOrigins(allowedOriginsArray);
             }
         };
     }

--- a/src/main/java/com/mealtiger/backend/BackendApplication.java
+++ b/src/main/java/com/mealtiger/backend/BackendApplication.java
@@ -17,7 +17,7 @@ import java.util.Properties;
  *
  * @author Lucca Greschner, Sebastian Maier
  */
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 public class BackendApplication implements CommandLineRunner {
 
     private static final Logger log = LoggerFactory.getLogger(BackendApplication.class);

--- a/src/main/java/com/mealtiger/backend/authentication/AuthenticationConfiguration.java
+++ b/src/main/java/com/mealtiger/backend/authentication/AuthenticationConfiguration.java
@@ -1,0 +1,53 @@
+package com.mealtiger.backend.authentication;
+
+import com.mealtiger.backend.configuration.Configurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Configuration for Spring Security
+ */
+@Configuration
+public class AuthenticationConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthenticationConfiguration.class);
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        Configurator configurator = new Configurator();
+
+        if(configurator.getBoolean("Authentication.OIDC.oidcAuthenticationStatus")) {
+            log.trace("Going through OIDC security filter chain!");
+
+            final String jwtIssuerURL = configurator.getString("Authentication.OIDC.authenticationProviderURL");
+
+            log.trace("Got jwt issuer URI {} from configuration!", jwtIssuerURL);
+
+            // Routes
+
+            final String recipes = "/recipes/**";
+
+            http.authorizeRequests(authorizeRequests -> authorizeRequests
+                            .antMatchers(HttpMethod.POST, recipes).authenticated()
+                            .antMatchers(HttpMethod.PUT, recipes).authenticated()
+                            .antMatchers(HttpMethod.DELETE, recipes).authenticated())
+                    .oauth2ResourceServer(oauth2ResourceServer ->
+                            oauth2ResourceServer
+                                    .jwt(jwt -> jwt.decoder(JwtDecoders.fromIssuerLocation(jwtIssuerURL)))
+                                    .jwt().jwtAuthenticationConverter(new CustomJwtAuthenticationConverter())
+                    );
+        }
+
+        //TODO: Figure out what CSRF is and configure postman to cope with it.
+        http.csrf().disable();
+        http.cors();
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/mealtiger/backend/authentication/CustomJwtAuthenticationConverter.java
+++ b/src/main/java/com/mealtiger/backend/authentication/CustomJwtAuthenticationConverter.java
@@ -1,0 +1,69 @@
+package com.mealtiger.backend.authentication;
+
+import com.mealtiger.backend.configuration.Configurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This custom JWT authentication converter guarantees that Spring recognizes roles set in keycloak.
+ */
+public class CustomJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomJwtAuthenticationConverter.class);
+
+
+    /**
+     * Extracts the resource roles from the JWT
+     *
+     * @param jwt JWT to extract roles from.
+     * @return Collection of granted authorities
+     */
+    private static Collection<? extends GrantedAuthority> extractResourceRoles(final Jwt jwt) {
+        Configurator configurator = new Configurator();
+        String clientID = configurator.getString("Authentication.OIDC.authenticationProviderURL");
+
+        log.trace("Got client id {} from configuration!", clientID);
+
+        Map<String, Object> resourceAccess = jwt.getClaim("resource_access");
+        if (resourceAccess == null) return Collections.emptySet();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> resource = (Map<String, Object>) resourceAccess.get(clientID);
+        if (resource == null) return Collections.emptySet();
+
+        @SuppressWarnings("unchecked")
+        Collection<String> resourceRoles = (Collection<String>) resource.get("roles");
+        if (resourceRoles == null) return Collections.emptySet();
+
+        return resourceRoles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Converts the Jwt into an JwtAuthenticationToken with the extracted authorities added.
+     *
+     * @param source the source object to convert, which must be an instance of {@code S} (never {@code null})
+     * @return JwtAuthenticationToken with the extracted authorities added.
+     */
+    @Override
+    public AbstractAuthenticationToken convert(@NonNull Jwt source) {
+        Collection<? extends GrantedAuthority> authorities = extractResourceRoles(source);
+
+        log.trace("Got the following resource roles from JWT: {}", authorities);
+
+        return new JwtAuthenticationToken(source, authorities);
+    }
+}

--- a/src/main/java/com/mealtiger/backend/configuration/configs/AuthenticationConfig.java
+++ b/src/main/java/com/mealtiger/backend/configuration/configs/AuthenticationConfig.java
@@ -1,0 +1,54 @@
+package com.mealtiger.backend.configuration.configs;
+
+import com.mealtiger.backend.configuration.annotations.Config;
+import com.mealtiger.backend.configuration.annotations.ConfigNode;
+
+/**
+ * Authentication Config File
+ * Properties are represented as non-static fields. Categories can be done by nesting the properties in static nested classes.
+ *
+ * @see com.mealtiger.backend.configuration.Configurator
+ */
+
+@Config(name = "Authentication", configPath = "auth.yml")
+@SuppressWarnings("unused")
+public class AuthenticationConfig {
+
+    private final OIDC oidc;
+
+    @SuppressWarnings("unused")
+    public AuthenticationConfig() {
+        this.oidc = new OIDC();
+    }
+
+    @ConfigNode(name = "OIDC.oidcAuthenticationStatus", envKey = "OIDC_AUTHENTICATION_ENABLED")
+    public boolean isOIDCAuthenticationEnabled() {
+        return oidc.enableOIDCAuthentication;
+    }
+
+    @ConfigNode(name = "OIDC.authenticationProviderURL", envKey = "OIDC_AUTHENTICATION_PROVIDER_URL")
+    public String getAuthenticationProviderURL() {
+        return oidc.authenticationProviderURL;
+    }
+
+    @ConfigNode(name = "OIDC.clientID", envKey = "OIDC_CLIENT_ID")
+    public String getOIDCClientID() {
+        return oidc.clientID;
+    }
+
+    static class OIDC {
+        private final boolean enableOIDCAuthentication;
+        private final String authenticationProviderURL;
+        private final String clientID;
+
+        OIDC() {
+            //TODO: Set the default to true once implemented in frontend!
+            this.enableOIDCAuthentication = false;
+
+            this.authenticationProviderURL = "";
+
+            this.clientID = "mealtiger";
+        }
+    }
+
+}


### PR DESCRIPTION
This enables the backend application to authenticate users through JSON Web Tokens issued by an Open ID Connect Provider. Due to lack of access to other commercially available authentication providers, this feature is currently only tested through the Keycloak Authentication Provider. 

Closes #38 