### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,6 @@ jobs:
           OIDC_AUTHENTICATION_PROVIDER_URL: https://auth.lifeminer.de/realms/meal-tiger-test
           DBURL: mongodb://localhost:27017
       - name: Building with Maven
-        run: mvn package --file pom.xml
+        run: mvn package -DskipTests --file pom.xml
         env:
             LOGLEVEL: debug

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,6 @@ jobs:
         run: mvn package --file pom.xml
         env:
           LOGLEVEL: debug
-          DBURL: mongodb://localhost:27017
       - name: Integration tests with Maven
         run: mvn verify --file pom.xml
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,9 +21,13 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-      - name: Build and test with Maven
+      - name: Unit tests and building with Maven
         run: mvn package --file pom.xml
         env:
+          LOGLEVEL: debug
+      - name: Integration tests with Maven
+        run: mvn verify --file pom.xml
+        env:
+          LOGLEVEL: debug
           OIDC_AUTHENTICATION_PROVIDER_URL: https://auth.lifeminer.de/realms/meal-tiger-test
           DBURL: mongodb://localhost:27017
-          LOGLEVEL: debug

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,7 @@ jobs:
         run: mvn package --file pom.xml
         env:
           LOGLEVEL: debug
+          DBURL: mongodb://localhost:27017
       - name: Integration tests with Maven
         run: mvn verify --file pom.xml
         env:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,17 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-      - name: Unit tests and building with Maven
-        run: mvn package --file pom.xml
+      - name: Unit tests
+        run: mvn test --file pom.xml
         env:
           LOGLEVEL: debug
       - name: Integration tests with Maven
-        run: mvn verify --file pom.xml
+        run: mvn failsafe:integration-test --file pom.xml
         env:
           LOGLEVEL: debug
           OIDC_AUTHENTICATION_PROVIDER_URL: https://auth.lifeminer.de/realms/meal-tiger-test
           DBURL: mongodb://localhost:27017
+      - name: Building with Maven
+        run: mvn package --file pom.xml
+        env:
+            LOGLEVEL: debug

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,28 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <groups>unit</groups>
+                </configuration>
             </plugin>
             <!-- maven failsafe plugin for integration testing -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <includes>
+                        <include>%regex[.*]</include>
+                    </includes>
+                    <groups>integration</groups>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>3.0.0-M5</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <!-- spring boot maven plugin -->
             <plugin>

--- a/src/main/java/com/mealtiger/backend/configuration/Configurator.java
+++ b/src/main/java/com/mealtiger/backend/configuration/Configurator.java
@@ -264,15 +264,15 @@ public class Configurator {
         try {
             if (returnType == String.class) {
                 returnValue = envValue;
-            } else if (returnType == Integer.class) {
+            } else if (returnType.getSimpleName().equalsIgnoreCase("integer")) {
                 returnValue = Integer.valueOf(envValue);
-            } else if (returnType == Boolean.class) {
+            } else if (returnType.getSimpleName().equalsIgnoreCase("boolean")) {
                 switch (envValue.toLowerCase()) {
                     case "true" -> returnValue = Boolean.TRUE;
                     case "false" -> returnValue = Boolean.FALSE;
                     default -> throw new IllegalArgumentException();
                 }
-            } else if (returnType == Double.class) {
+            } else if (returnType.getSimpleName().equalsIgnoreCase("double")) {
                 returnValue = Double.valueOf(envValue);
             }
         } catch (Exception e) {

--- a/src/test/java/com/mealtiger/backend/authentication/CustomJwtAuthenticationConverterTest.java
+++ b/src/test/java/com/mealtiger/backend/authentication/CustomJwtAuthenticationConverterTest.java
@@ -1,6 +1,7 @@
 package com.mealtiger.backend.authentication;
 
 import com.mealtiger.backend.configuration.Configurator;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("unit")
 class CustomJwtAuthenticationConverterTest {
 
     /**

--- a/src/test/java/com/mealtiger/backend/configuration/ConfigurationTest.java
+++ b/src/test/java/com/mealtiger/backend/configuration/ConfigurationTest.java
@@ -3,6 +3,7 @@ package com.mealtiger.backend.configuration;
 import com.mealtiger.backend.configuration.configs.TestConfig;
 import com.mealtiger.backend.configuration.exceptions.NoSuchConfigException;
 import com.mealtiger.backend.configuration.exceptions.NoSuchPropertyException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.yaml.snakeyaml.TypeDescription;
 
@@ -14,6 +15,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Tag("unit")
 class ConfigurationTest {
 
     @Test

--- a/src/test/java/com/mealtiger/backend/database/model/image_metadata/validation/ImageValidatorTest.java
+++ b/src/test/java/com/mealtiger/backend/database/model/image_metadata/validation/ImageValidatorTest.java
@@ -2,6 +2,7 @@ package com.mealtiger.backend.database.model.image_metadata.validation;
 
 import com.mealtiger.backend.configuration.Configurator;
 import com.mealtiger.backend.rest.Helper;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Tag("unit")
 class ImageValidatorTest {
     private static final String NON_EXISTENT_IMAGE_ID = "f2076c35-e8d1-4d34-82f1-0de7f370efbd";
 

--- a/src/test/java/com/mealtiger/backend/database/model/recipe/RatingTest.java
+++ b/src/test/java/com/mealtiger/backend/database/model/recipe/RatingTest.java
@@ -3,11 +3,13 @@ package com.mealtiger.backend.database.model.recipe;
 import com.mealtiger.backend.SampleSource;
 import com.mealtiger.backend.rest.model.rating.RatingRequest;
 import com.mealtiger.backend.rest.model.rating.RatingResponse;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Tag("unit")
 class RatingTest {
 
     @Test

--- a/src/test/java/com/mealtiger/backend/database/model/recipe/RecipeTest.java
+++ b/src/test/java/com/mealtiger/backend/database/model/recipe/RecipeTest.java
@@ -3,6 +3,7 @@ package com.mealtiger.backend.database.model.recipe;
 import com.mealtiger.backend.SampleSource;
 import com.mealtiger.backend.rest.model.recipe.RecipeRequest;
 import com.mealtiger.backend.rest.model.recipe.RecipeResponse;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier
  */
+@Tag("unit")
 class RecipeTest {
 
     /**

--- a/src/test/java/com/mealtiger/backend/database/repository/RecipeRepositoryTest.java
+++ b/src/test/java/com/mealtiger/backend/database/repository/RecipeRepositoryTest.java
@@ -7,6 +7,7 @@ import com.mealtiger.backend.database.model.recipe.Recipe;
 import com.mealtiger.backend.SampleSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
         classes = {BackendApplication.class}
 )
+@Tag("integration")
 class RecipeRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/FactoryTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/FactoryTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * This class tests the ImageAdapterFactory.
  */
 @SpringBootTest
-@Tag("unit")
+@Tag("integration")
 class FactoryTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/FactoryTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/FactoryTest.java
@@ -1,6 +1,7 @@
 package com.mealtiger.backend.imageio;
 
 import com.mealtiger.backend.imageio.adapters.*;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * This class tests the ImageAdapterFactory.
  */
 @SpringBootTest
+@Tag("unit")
 class FactoryTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
@@ -1,10 +1,10 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -19,12 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier, Lucca Greschner
  */
-@SpringBootTest
 @Tag("unit")
 class BitmapAdapterTest {
 
-    @Autowired
     private ImageAdapter bitmapAdapter;
+
+    @BeforeEach
+    @AfterEach
+    void beforeAfterEach() {
+        bitmapAdapter = new BitmapAdapter();
+    }
 
     /**
      * Tests conversion of bitmap images

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Sebastian Maier, Lucca Greschner
  */
 @SpringBootTest
+@Tag("unit")
 class BitmapAdapterTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
@@ -1,10 +1,10 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -19,12 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier, Lucca Greschner
  */
-@SpringBootTest
 @Tag("unit")
 class GIFAdapterTest {
 
-    @Autowired
     private ImageAdapter gifAdapter;
+
+    @BeforeEach
+    @AfterEach
+    void beforeAfterEach() {
+        gifAdapter = new GIFAdapter();
+    }
 
     /**
      * Tests conversion of bitmap images

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Sebastian Maier, Lucca Greschner
  */
 @SpringBootTest
+@Tag("unit")
 class GIFAdapterTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Sebastian Maier, Lucca Greschner
  */
 @SpringBootTest
+@Tag("unit")
 class JPEGAdapterTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
@@ -1,10 +1,10 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -19,12 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier, Lucca Greschner
  */
-@SpringBootTest
 @Tag("unit")
 class JPEGAdapterTest {
 
-    @Autowired
     private ImageAdapter jpegAdapter;
+
+    @BeforeEach
+    @AfterEach
+    void beforeAfterEach() {
+        jpegAdapter = new JPEGAdapter();
+    }
 
     /**
      * Tests conversion of bitmap images

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
@@ -1,10 +1,10 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -19,12 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier, Lucca Greschner
  */
-@SpringBootTest
 @Tag("unit")
 class PNGAdapterTest {
 
-    @Autowired
     private ImageAdapter pngAdapter;
+
+    @BeforeEach
+    @AfterEach
+    void beforeAfterEach() {
+        pngAdapter = new PNGAdapter();
+    }
 
     /**
      * Tests conversion of bitmap images

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Sebastian Maier, Lucca Greschner
  */
 @SpringBootTest
+@Tag("unit")
 class PNGAdapterTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
@@ -1,10 +1,10 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -19,12 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @author Sebastian Maier, Lucca Greschner
  */
-@SpringBootTest
 @Tag("unit")
 class WebPAdapterTest {
 
-    @Autowired
     private ImageAdapter webPAdapter;
+
+    @BeforeEach
+    @AfterEach
+    void beforeAfterEach() {
+        webPAdapter = new WebPAdapter();
+    }
 
     /**
      * Tests conversion of bitmap images

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.imageio.adapters;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Sebastian Maier, Lucca Greschner
  */
 @SpringBootTest
+@Tag("unit")
 class WebPAdapterTest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
+++ b/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
@@ -5,6 +5,7 @@ import com.mealtiger.backend.configuration.Configurator;
 import com.mealtiger.backend.rest.controller.ImageIOController;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,6 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         webEnvironment = SpringBootTest.WebEnvironment.MOCK,
         classes = {BackendApplication.class}
 )
+@Tag("integration")
 class ImageAPITest {
     
     @Autowired

--- a/src/test/java/com/mealtiger/backend/rest/RatingAPITest.java
+++ b/src/test/java/com/mealtiger/backend/rest/RatingAPITest.java
@@ -10,6 +10,7 @@ import com.mealtiger.backend.database.repository.RecipeRepository;
 import com.mealtiger.backend.rest.model.rating.RatingRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         classes = {BackendApplication.class}
 )
 @AutoConfigureMockMvc
+@Tag("integration")
 class RatingAPITest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/rest/RecipeAPITest.java
+++ b/src/test/java/com/mealtiger/backend/rest/RecipeAPITest.java
@@ -14,6 +14,7 @@ import com.mealtiger.backend.rest.model.recipe.RecipeRequest;
 import com.mealtiger.backend.rest.model.recipe.RecipeResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,6 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         classes = {BackendApplication.class}
 )
 @AutoConfigureMockMvc
+@Tag("integration")
 class RecipeAPITest {
 
     @Autowired

--- a/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
@@ -8,6 +8,7 @@ import com.mealtiger.backend.rest.Helper;
 import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @MockitoSettings
+@Tag("unit")
 class ImageIOControllerTest {
 
     @Mock

--- a/src/test/java/com/mealtiger/backend/rest/controller/RecipeControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/RecipeControllerTest.java
@@ -13,10 +13,7 @@ import com.mealtiger.backend.rest.model.rating.RatingRequest;
 import com.mealtiger.backend.rest.model.rating.RatingResponse;
 import com.mealtiger.backend.rest.model.recipe.RecipeRequest;
 import com.mealtiger.backend.rest.model.recipe.RecipeResponse;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -36,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@Tag("unit")
 class RecipeControllerTest {
 
     private static final RecipeRequest SAMPLE_RECIPE_DTO = new RecipeRequest();

--- a/src/test/java/com/mealtiger/backend/rest/controller/RecipeControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/RecipeControllerTest.java
@@ -14,9 +14,6 @@ import com.mealtiger.backend.rest.model.rating.RatingResponse;
 import com.mealtiger.backend.rest.model.recipe.RecipeRequest;
 import com.mealtiger.backend.rest.model.recipe.RecipeResponse;
 import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +29,6 @@ import static com.mealtiger.backend.SampleSource.SAMPLE_USER_ID;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
 @Tag("unit")
 class RecipeControllerTest {
 
@@ -52,10 +48,8 @@ class RecipeControllerTest {
             new UUID[]{}
     );
 
-    @MockBean
     private RecipeRepository recipeRepository;
 
-    @Autowired
     private RecipeController recipeController;
 
     /**
@@ -78,7 +72,8 @@ class RecipeControllerTest {
     @BeforeEach
     @AfterEach
     void beforeAfterEach() {
-        recipeRepository.deleteAll();
+        recipeRepository = mock(RecipeRepository.class);
+        recipeController = new RecipeController(recipeRepository);
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/rest/model/RatingRequestTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/model/RatingRequestTest.java
@@ -2,6 +2,7 @@ package com.mealtiger.backend.rest.model;
 
 import com.mealtiger.backend.rest.model.rating.RatingRequest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.Validation;
@@ -11,6 +12,7 @@ import javax.validation.ValidatorFactory;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unit")
 class RatingRequestTest {
 
     private static Validator validator;

--- a/src/test/java/com/mealtiger/backend/rest/model/RecipeRequestTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/model/RecipeRequestTest.java
@@ -3,6 +3,7 @@ package com.mealtiger.backend.rest.model;
 import com.mealtiger.backend.database.model.recipe.Ingredient;
 import com.mealtiger.backend.rest.model.recipe.RecipeRequest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.Validation;
@@ -14,6 +15,7 @@ import static com.mealtiger.backend.SampleSource.SAMPLE_USER_ID;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Tag("unit")
 class RecipeRequestTest {
 
     private static Validator validator;


### PR DESCRIPTION
Integration tests should be run with the maven failsafe plugin whereas unit tests should be run with the maven surefire plugin. This should guarantee that the application builds even when the integration tests fail.