### PR TITLE
Fix #88

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM eclipse-temurin:17-alpine
+FROM eclipse-temurin:17
 COPY ./target/*.jar /app.jar
 RUN mkdir /config
 WORKDIR /config

--- a/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
+++ b/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
@@ -70,7 +70,7 @@ public class ImageAPI {
                 }
                 controller.saveImage(image, String.valueOf(uuid), userId);
             } catch (IOException e) {
-                throw new UploadException("Could not open uploaded file " + file.getName());
+                throw new UploadException("Could not open uploaded file " + file.getName() + ". Reason: " + e.getMessage());
             } finally {
                 uuids.add(uuid);
             }


### PR DESCRIPTION
This fixes webp conversion in the docker container. The backend depends on glibc being installed. However, the old docker image was based on alpine linux which uses musl instead of glibc. Now, the docker image uses debian as a base.