### PR TITLE
Improve image conversion speeds

### DIFF
--- a/src/main/java/com/mealtiger/backend/imageio/adapters/WebPAdapter.java
+++ b/src/main/java/com/mealtiger/backend/imageio/adapters/WebPAdapter.java
@@ -16,8 +16,7 @@ public class WebPAdapter implements ImageAdapter {
 
     @Override
     public byte[] convert(BufferedImage input) throws IllegalStateException, IllegalArgumentException, IOException {
-        PNGAdapter pngAdapter = new PNGAdapter();
-        ImmutableImage image = ImmutableImage.loader().fromBytes(pngAdapter.convert(input));
+        ImmutableImage image = ImmutableImage.fromAwt(input);
 
         Configurator configurator = new Configurator();
         String compressionType = configurator.getString("Image.WebP.compressionType");

--- a/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
+++ b/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
@@ -17,10 +17,8 @@ import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,8 +57,8 @@ public class ImageAPI {
 
         for(MultipartFile file : files) {
             UUID uuid = UUID.randomUUID();
-            try (InputStream inputStream = file.getInputStream()) {
-                BufferedImage image = ImageIO.read(inputStream);
+            try {
+                BufferedImage image = controller.readImage(file);
                 if (image == null) {
                     // Image format is not supported!
                     for (UUID alreadySavedUUID : uuids) {
@@ -95,8 +93,8 @@ public class ImageAPI {
 
         UUID uuid = UUID.randomUUID();
 
-        try (InputStream inputStream = file.getInputStream()) {
-            BufferedImage image = ImageIO.read(inputStream);
+        try {
+            BufferedImage image = controller.readImage(file);
             if (image == null) {
                 // Image format is not supported!
                 throw new InvalidRequestFormatException("Image format not supported!");

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -21,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.file.*;
@@ -96,7 +97,6 @@ public class ImageIOController {
 
             try {
                 reader.setInput(imageInputStream);
-
                 image = reader.read(0);
             } finally {
                 reader.dispose();
@@ -129,6 +129,12 @@ public class ImageIOController {
         if (!filePath.exists() && !filePath.mkdir()) {
             throw new IllegalStateException("Couldn't create directory: " + filePath);
         }
+
+        // Convert the image type to a byte indexed image to drastically improve performance.
+        BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+        Graphics2D graphics2D = indexedImage.createGraphics();
+        graphics2D.drawImage(image, 0, 0, null);
+        image = indexedImage;
 
         for (String format : servedFormatsSplitted) {
             byte[] imageBytes;

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -94,7 +94,6 @@ public class ImageIOController {
             }
 
             ImageReader reader = readers.next();
-            log.info(reader.getClass().getName());
 
             try {
                 reader.setInput(imageInputStream);

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -6,6 +6,7 @@ import com.mealtiger.backend.database.repository.ImageMetadataRepository;
 import com.mealtiger.backend.imageio.adapters.ImageAdapter;
 import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundException;
 import com.mealtiger.backend.rest.error_handling.exceptions.ImageFormatNotServedException;
+import com.mealtiger.backend.rest.error_handling.exceptions.InvalidRequestFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -89,7 +90,7 @@ public class ImageIOController {
             Iterator<ImageReader> readers = ImageIO.getImageReaders(imageInputStream);
 
             if (!readers.hasNext()) {
-                throw new IllegalArgumentException("Unknown image format!");
+                throw new InvalidRequestFormatException("Unknown image format!");
             }
 
             ImageReader reader = readers.next();

--- a/src/test/java/com/mealtiger/backend/imageio/ImageSource.java
+++ b/src/test/java/com/mealtiger/backend/imageio/ImageSource.java
@@ -1,6 +1,7 @@
 package com.mealtiger.backend.imageio;
 
 import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Objects;
@@ -14,12 +15,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of bitmap test images.
      */
     static Stream<BufferedImage> bitmapImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.bmp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.bmp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.bmp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.bmp")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -27,11 +34,17 @@ public class ImageSource {
      * @return Stream containing BufferedImages of jpeg test images.
      */
     static Stream<BufferedImage> jpegImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.jpg"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.jpg"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.jpg")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -39,12 +52,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of png test images.
      */
     static Stream<BufferedImage> pngImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.png"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.png"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.png"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.png")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -52,12 +71,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of gif test images.
      */
     static Stream<BufferedImage> gifImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.gif"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.gif"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.gif"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.gif")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -65,12 +90,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of lossy webp test images.
      */
     static Stream<BufferedImage> lossyWebPImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.webp")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -78,12 +109,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of lossless webp test images.
      */
     static Stream<BufferedImage> losslessWebPImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.lossless.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.lossless.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.lossless.webp"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.lossless.webp")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
     /**
@@ -91,12 +128,18 @@ public class ImageSource {
      * @return Stream containing BufferedImages of tiff test images.
      */
     static Stream<BufferedImage> tiffImageStream() throws IOException {
+        ImageIO.setUseCache(false);
         return Stream.of(
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.tiff"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/Flower/TestImage.tiff"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/PiggyBank/TestImage.tiff"))),
                 ImageIO.read(Objects.requireNonNull(ImageSource.class.getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/TransparentTestImage/TestImage.tiff")))
-        );
+        ).map(image -> {
+            BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
+            Graphics2D graphics2D = indexedImage.createGraphics();
+            graphics2D.drawImage(image, 0, 0, null);
+            return indexedImage;
+        });
     }
 
 }

--- a/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
+++ b/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
@@ -2,6 +2,7 @@ package com.mealtiger.backend.rest;
 
 import com.mealtiger.backend.BackendApplication;
 import com.mealtiger.backend.configuration.Configurator;
+import com.mealtiger.backend.database.repository.ImageMetadataRepository;
 import com.mealtiger.backend.rest.controller.ImageIOController;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +63,9 @@ class ImageAPITest {
     private ImageIOController imageIOController;
 
     @Autowired
+    private ImageMetadataRepository imageMetadataRepository;
+
+    @Autowired
     private MockMvc mvc;
 
     @MockBean(answer = Answers.CALLS_REAL_METHODS)
@@ -76,6 +80,7 @@ class ImageAPITest {
         if(Files.exists(Path.of(configurator.getString("Image.imagePath")))) {
             Helper.deleteFile(Path.of(configurator.getString("Image.imagePath")));
         }
+        imageMetadataRepository.deleteAll();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
@@ -73,21 +73,21 @@ class ImageIOControllerTest {
 
         ImageIOController controller = new ImageIOController(bitmapAdapter, gifAdapter, jpegAdapter, pngAdapter, webPAdapter, configurator, imageMetadataRepository);
 
-        BufferedImage image = mock(BufferedImage.class);
+        BufferedImage image = new BufferedImage(256,256,BufferedImage.TYPE_INT_RGB);
 
-        when(bitmapAdapter.convert(image)).thenReturn(new byte[]{});
-        when(jpegAdapter.convert(image)).thenReturn(new byte[]{});
-        when(gifAdapter.convert(image)).thenReturn(new byte[]{});
-        when(pngAdapter.convert(image)).thenReturn(new byte[]{});
-        when(webPAdapter.convert(image)).thenReturn(new byte[]{});
+        when(bitmapAdapter.convert(any())).thenReturn(new byte[]{});
+        when(jpegAdapter.convert(any())).thenReturn(new byte[]{});
+        when(gifAdapter.convert(any())).thenReturn(new byte[]{});
+        when(pngAdapter.convert(any())).thenReturn(new byte[]{});
+        when(webPAdapter.convert(any())).thenReturn(new byte[]{});
 
         controller.saveImage(image, SAMPLE_IMAGE_ID, SAMPLE_USER_ID);
 
-        verify(bitmapAdapter).convert(image);
-        verify(jpegAdapter).convert(image);
-        verify(gifAdapter).convert(image);
-        verify(pngAdapter).convert(image);
-        verify(webPAdapter).convert(image);
+        verify(bitmapAdapter).convert(any());
+        verify(jpegAdapter).convert(any());
+        verify(gifAdapter).convert(any());
+        verify(pngAdapter).convert(any());
+        verify(webPAdapter).convert(any());
 
         verify(imageMetadataRepository).save(new ImageMetadata(SAMPLE_IMAGE_ID, SAMPLE_USER_ID));
     }

--- a/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 
 import java.awt.image.BufferedImage;
@@ -61,6 +62,23 @@ class ImageIOControllerTest {
         if(Files.exists(imagePath)) {
             Helper.deleteFile(imagePath);
         }
+    }
+
+    /**
+     * Tests reading images.
+     */
+    @Test
+    void readImageTest() throws IOException {
+        when(configurator.getString("Image.imagePath")).thenReturn("testImages/");
+
+        ImageIOController controller = new ImageIOController(bitmapAdapter, gifAdapter, jpegAdapter, pngAdapter, webPAdapter, configurator, imageMetadataRepository);
+
+        MockMultipartFile multipartFile = spy(new MockMultipartFile("file", this.getClass().getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.jpg")));
+        BufferedImage image = controller.readImage(multipartFile);
+
+        verify(multipartFile).getInputStream();
+        assertNotEquals(0, image.getHeight());
+        assertNotEquals(0, image.getWidth());
     }
 
     /**


### PR DESCRIPTION
By using memory cache, loading webp through the fromAwt method and converting BufferedImages to the type BYTE_INDEXED before they are converted I achieved the following performance improvements:

WebP Improvement: ~33% faster
Overall image writing: ~50% faster
End-to-end posting images (small images): ~35% faster
Recipe creation (realistical image file size ~1.2MB): ~50-60% faster

I didn't implement multi threaded uploads as this would lead to problems as ImageIO is not thread safe. In order to make it thread safe we'd need to limit an ExecutorService to one thread which would not solve any problem but would just call the readImage and saveImage asynchronously. This is not what we want as we need blocking methods in this situation to give the user correct feedback whether his images were accepted or not.