### PR TITLE
Improve image conversion

### DIFF
--- a/src/main/java/com/mealtiger/backend/configuration/configs/ImageConfig.java
+++ b/src/main/java/com/mealtiger/backend/configuration/configs/ImageConfig.java
@@ -109,6 +109,21 @@ public class ImageConfig {
         return webp.compressionType;
     }
 
+    @ConfigNode(name = "WebP.compressionFactor")
+    public int getWebPCompressionFactor() {
+        return webp.compressionFactor;
+    }
+
+    @ConfigNode(name = "WebP.compressionMethod")
+    public int getWebPCompressionMethod() {
+        return webp.compressionMethod;
+    }
+
+    @ConfigNode(name = "WebP.losslessSpeedFactor")
+    public int getWebPlosslessSpeedFactor() {
+        return webp.losslessSpeedFactor;
+    }
+
     @ConfigNode(name = "imagePath", envKey = "IMAGE_PATH")
     public String getImagePath() {
         return imagePath;
@@ -169,11 +184,17 @@ public class ImageConfig {
         private final boolean enabled;
         private final String compressionType;
         private final double qualityWeighting;
+        private final int compressionFactor;
+        private final int compressionMethod;
+        private final int losslessSpeedFactor;
 
         private WebP() {
             enabled = true;
             compressionType = "DEFAULT";
             qualityWeighting = 1.0;
+            compressionFactor = 75;
+            compressionMethod = 4;
+            losslessSpeedFactor = 6;
         }
     }
 }

--- a/src/main/java/com/mealtiger/backend/imageio/adapters/BitmapAdapter.java
+++ b/src/main/java/com/mealtiger/backend/imageio/adapters/BitmapAdapter.java
@@ -46,7 +46,7 @@ public class BitmapAdapter implements ImageAdapter {
         BufferedImage input;
         if (image.getColorModel().hasAlpha()) {
             // Remove alpha channel
-            BufferedImage newImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+            BufferedImage newImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
             Graphics2D graphics2D = newImage.createGraphics();
             graphics2D.fillRect(0,0, image.getWidth(), image.getHeight());
             graphics2D.drawImage(image, 0, 0, null);

--- a/src/main/java/com/mealtiger/backend/imageio/adapters/JPEGAdapter.java
+++ b/src/main/java/com/mealtiger/backend/imageio/adapters/JPEGAdapter.java
@@ -43,7 +43,7 @@ public class JPEGAdapter implements ImageAdapter {
         BufferedImage input;
         if (image.getColorModel().hasAlpha()) {
             // Remove alpha channel
-            BufferedImage newImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+            BufferedImage newImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
             Graphics2D graphics2D = newImage.createGraphics();
             graphics2D.fillRect(0,0, image.getWidth(), image.getHeight());
             graphics2D.drawImage(image, 0, 0, null);

--- a/src/main/java/com/mealtiger/backend/imageio/adapters/WebPAdapter.java
+++ b/src/main/java/com/mealtiger/backend/imageio/adapters/WebPAdapter.java
@@ -23,8 +23,27 @@ public class WebPAdapter implements ImageAdapter {
 
         if ("DEFAULT".equals(compressionType)) {
             return image.bytes(WebpWriter.DEFAULT);
+        } else if ("LOSSLESS".equals(compressionType)) {
+            return image.bytes(WebpWriter.MAX_LOSSLESS_COMPRESSION);
+        } else if ("CUSTOM".equals(compressionType)) {
+            int compressionFactor = configurator.getInteger("Image.WebP.compressionFactor");
+            int compressionMethod = configurator.getInteger("Image.WebP.compressionMethod");
+            return image.bytes(WebpWriter.DEFAULT
+                    .withQ(compressionFactor)
+                    .withM(compressionMethod)
+            );
+        } else if ("CUSTOM_LOSSLESS".equals(compressionType)) {
+            int compressionFactor = configurator.getInteger("Image.WebP.compressionFactor");
+            int compressionMethod = configurator.getInteger("Image.WebP.compressionMethod");
+            int losslessSpeedFactor = configurator.getInteger("Image.WebP.losslessSpeedFactor");
+            return image.bytes(WebpWriter.MAX_LOSSLESS_COMPRESSION
+                    .withZ(losslessSpeedFactor)
+                    .withQ(compressionFactor)
+                    .withM(compressionMethod)
+            );
         }
-
-        return image.bytes(WebpWriter.MAX_LOSSLESS_COMPRESSION);
+        else {
+            throw new IllegalArgumentException("No such compressionType as " + compressionType + "!");
+        }
     }
 }

--- a/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
+++ b/src/main/java/com/mealtiger/backend/rest/api/ImageAPI.java
@@ -58,14 +58,17 @@ public class ImageAPI {
         for(MultipartFile file : files) {
             UUID uuid = UUID.randomUUID();
             try {
+                log.trace("Reading uploaded image!");
                 BufferedImage image = controller.readImage(file);
                 if (image == null) {
                     // Image format is not supported!
+                    log.error("Error occured when reading image. Possibly, the image format is not supported! Aborting!");
                     for (UUID alreadySavedUUID : uuids) {
                         deleteImage(alreadySavedUUID.toString());
                     }
                     throw new InvalidRequestFormatException("Image format not supported!");
                 }
+                log.trace("Saving uploaded image!");
                 controller.saveImage(image, String.valueOf(uuid), userId);
             } catch (IOException e) {
                 throw new UploadException("Could not open uploaded file " + file.getName() + ". Reason: " + e.getMessage());

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -7,6 +7,7 @@ import com.mealtiger.backend.imageio.adapters.ImageAdapter;
 import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundException;
 import com.mealtiger.backend.rest.error_handling.exceptions.ImageFormatNotServedException;
 import com.mealtiger.backend.rest.error_handling.exceptions.InvalidRequestFormatException;
+import com.mealtiger.backend.rest.error_handling.exceptions.UploadException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -29,6 +30,8 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
 
 /**
  * This class provides a facade to the ImageIO implementation.
@@ -112,7 +115,9 @@ public class ImageIOController {
      * @param uuid ID of the image.
      * @param userId ID of the user.
      */
-    public void saveImage(BufferedImage image, String uuid, String userId) throws IOException {
+    public void saveImage(BufferedImage image, String uuid, String userId) throws IOException, UploadException {
+        log.trace("Saving image with uuid {}, uploaded by user {}", uuid, userId);
+
         String servedFormats = configurator.getString("Image.servedImageFormats");
         List<String> servedFormatsSplitted = List.of(servedFormats.split(","));
 
@@ -130,25 +135,73 @@ public class ImageIOController {
             throw new IllegalStateException("Couldn't create directory: " + filePath);
         }
 
+        log.trace("Converting image to type byte_indexed!");
+
         // Convert the image type to a byte indexed image to drastically improve performance.
         BufferedImage indexedImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_INDEXED);
         Graphics2D graphics2D = indexedImage.createGraphics();
         graphics2D.drawImage(image, 0, 0, null);
         image = indexedImage;
 
-        for (String format : servedFormatsSplitted) {
-            byte[] imageBytes;
+        int threadCount = Runtime.getRuntime().availableProcessors();
 
+        log.trace("Starting executor service for image conversion. Thread count: {}", threadCount);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        BufferedImage finalImage = image;
+
+        Callable<byte[]> bitmapConversion = () -> bitmapAdapter.convert(finalImage);
+        Callable<byte[]> jpegConversion = () -> jpegAdapter.convert(finalImage);
+        Callable<byte[]> gifConversion = () -> gifAdapter.convert(finalImage);
+        Callable<byte[]> pngConversion = () -> pngAdapter.convert(finalImage);
+        Callable<byte[]> webPConversion = () -> webPAdapter.convert(finalImage);
+
+        Map<String, Future<byte[]>> imageByteMap = new ConcurrentHashMap<>();
+
+        for (String format : servedFormatsSplitted) {
             switch (format) {
-                case "bmp" -> imageBytes = bitmapAdapter.convert(image);
-                case "jpeg" -> imageBytes = jpegAdapter.convert(image);
-                case "gif" -> imageBytes = gifAdapter.convert(image);
-                case "png" -> imageBytes = pngAdapter.convert(image);
-                case "webp" -> imageBytes = webPAdapter.convert(image);
-                default -> throw new IllegalArgumentException("Image format unknown: " + format);
+                case "bmp" -> {
+                    log.trace("Submitting conversion to format bitmap!");
+                    imageByteMap.put("bmp", executorService.submit(bitmapConversion));
+                }
+                case "jpeg" -> {
+                    log.trace("Submitting conversion to format jpeg!");
+                    imageByteMap.put("jpeg", executorService.submit(jpegConversion));
+                }
+                case "gif" -> {
+                    log.trace("Submitting conversion to format gif!");
+                    imageByteMap.put("gif", executorService.submit(gifConversion));
+                }
+                case "png" -> {
+                    log.trace("Submitting conversion to format png!");
+                    imageByteMap.put("png", executorService.submit(pngConversion));
+                }
+                case "webp" -> {
+                    log.trace("Submitting conversion to format webp!");
+                    imageByteMap.put("webp", executorService.submit(webPConversion));
+                }
+                default -> {
+                    log.error("Image format of name {} unknown!", format);
+                    throw new IllegalArgumentException("Image format unknown: " + format);
+                }
+            }
+        }
+
+        for (Map.Entry<String, Future<byte[]>> entry : imageByteMap.entrySet()) {
+            byte[] imageBytes;
+            String format = entry.getKey();
+
+            try {
+                log.trace("Trying to retrieve image bytes of type {}!", format);
+                imageBytes = entry.getValue().get();
+            } catch (InterruptedException | ExecutionException e) {
+                Thread.currentThread().interrupt();
+                throw new UploadException(e.getMessage());
             }
 
-            File file = new File(path + uuid + "/image." + format);
+            String imagePath = path + uuid + "/image." + format;
+            log.trace("Saving image of format {} on path {}.", format, imagePath);
+            File file = new File(imagePath);
             if (!file.createNewFile()) {
                 throw new IllegalStateException("Couldn't create file: " + file);
             }
@@ -158,6 +211,7 @@ public class ImageIOController {
             }
         }
 
+        log.trace("Saving metadata of image {} to database!", uuid);
         imageMetadataRepository.save(new ImageMetadata(uuid, userId));
     }
 

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -8,6 +8,7 @@ import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundExcept
 import com.mealtiger.backend.rest.error_handling.exceptions.ImageFormatNotServedException;
 import com.mealtiger.backend.rest.error_handling.exceptions.InvalidRequestFormatException;
 import com.mealtiger.backend.rest.error_handling.exceptions.UploadException;
+import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -25,7 +26,10 @@ import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Iterator;
@@ -87,7 +91,7 @@ public class ImageIOController {
     public BufferedImage readImage(MultipartFile file) throws IOException {
         BufferedImage image;
 
-        try (InputStream inputStream = file.getInputStream(); ImageInputStream imageInputStream = ImageIO.createImageInputStream(inputStream)) {
+        try (ImageInputStream imageInputStream = new ByteArrayImageInputStream(file.getBytes())) {
             ImageIO.setUseCache(false);
 
             Iterator<ImageReader> readers = ImageIO.getImageReaders(imageInputStream);

--- a/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
+++ b/src/main/java/com/mealtiger/backend/rest/controller/ImageIOController.java
@@ -315,7 +315,7 @@ public class ImageIOController {
                     .body(resource);
         } catch (FileNotFoundException | NoSuchFileException e) {
             log.debug("File {} not found!", path);
-            throw new EntityNotFoundException("Image of MediaType" + type + " not found!");
+            throw new EntityNotFoundException("Image of MediaType " + type + " not found!");
         } catch (IOException e) {
             log.error("Error upon downloading file {}: {}", imageRootPath, e.getMessage());
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/resources/configuration-samples/image.sample.yml
+++ b/src/main/resources/configuration-samples/image.sample.yml
@@ -18,8 +18,29 @@ imagePath: images/
 # Enabled by default, image format of choice with modern web pages/applications.
 webp:
   enabled: true
-  # Configures the compression type. Valid values are: DEFAULT, LOSSLESS
+  # Configures the compression type. Valid values are: DEFAULT, LOSSLESS, CUSTOM, CUSTOM_LOSSLESS
   compressionType: DEFAULT
+  # Only applies when compressionType CUSTOM or CUSTOM_LOSSLESS is set.
+  # Defines the compression factor the RGB channels are compressed with.
+  # Generally, the higher you set this, the smaller
+  # the disk space taken by an image will be.
+  # However, this comes at the cost of performance.
+  # Valid values range from 0 to 100.
+  compressionFactor: 75
+  # Only applies when compressionType CUSTOM or CUSTOM_LOSSLESS is set.
+  # Defines the compression method an image is compressed with.
+  # Generally, the higher you set this, the smaller
+  # the disk space taken by an image will be.
+  # However, this comes at the cost of performance.
+  # Valid values range from 0 to 6.
+  compressionMethod: 4
+  # Only applies when compressionType CUSTOM_LOSSLESS is set.
+  # Defines the pace an image is compressed with.
+  # Generally, the higher you set this, the smaller
+  # the disk space taken by an image will be.
+  # However, this comes at the cost of performance.
+  # Valid values range from 0 to 9.
+  losslessSpeedFactor: 6
   # The higher this number, the likelier it is that the
   # integrated algorithm chooses this image format.
   qualityWeighting: 1.0
@@ -29,7 +50,7 @@ webp:
 jpeg:
   enabled: true
   # Defines the quality of the saved image.
-  # Generally, the lower you set this, the smaller
+  # Generally, the higher you set this, the smaller
   # the disk space taken by an image will be. However,
   # this comes at the cost of image quality.
   compressionQuality: 75.0
@@ -42,7 +63,7 @@ jpeg:
 bmp:
   enabled: false
   # Defines the quality of the saved image.
-  # Generally, the lower you set this, the smaller
+  # Generally, the higher you set this, the smaller
   # the disk space taken by an image will be. However,
   # this comes at the cost of image quality.
   compressionQuality: 75.0
@@ -59,7 +80,7 @@ bmp:
 gif:
   enabled: false
   # Defines the quality of the saved image.
-  # Generally, the lower you set this, the smaller
+  # Generally, the higher you set this, the smaller
   # the disk space taken by an image will be. However,
   # this comes at the cost of image quality.
   compressionQuality: 75.0
@@ -74,7 +95,7 @@ gif:
 png:
   enabled: false
   # Defines the quality of the saved image.
-  # Generally, the lower you set this, the smaller
+  # Generally, the higher you set this, the smaller
   # the disk space taken by an image will be. However,
   # this comes at the cost of image quality.
   compressionQuality: 75.0

--- a/src/test/java/com/mealtiger/backend/UnitTestConfigSetup.java
+++ b/src/test/java/com/mealtiger/backend/UnitTestConfigSetup.java
@@ -1,0 +1,62 @@
+package com.mealtiger.backend;
+
+import com.mealtiger.backend.configuration.annotations.Config;
+import org.springframework.data.util.AnnotatedTypeScanner;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Set;
+
+public class UnitTestConfigSetup {
+
+    public static void setupConfigs() {
+        AnnotatedTypeScanner annotatedTypeScanner = new AnnotatedTypeScanner(false, Config.class);
+
+        Set<Class<?>> configSet = annotatedTypeScanner.findTypes("com.mealtiger.backend.configuration.configs");
+        
+        configSet.forEach(config -> {
+            String configPathString = config.getAnnotation(Config.class).configPath();
+            Path configPath = Path.of(configPathString);
+            if (Files.exists(configPath, LinkOption.NOFOLLOW_LINKS)) {
+                try {
+                    Path backupLocation = Path.of("configBackup");
+                    if (!Files.exists(backupLocation)) {
+                        Files.createDirectory(backupLocation);
+                    }
+                    Files.move(configPath, Path.of("configBackup", configPathString));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    public static void teardownConfigs() {
+        AnnotatedTypeScanner annotatedTypeScanner = new AnnotatedTypeScanner(false, Config.class);
+
+        Set<Class<?>> configSet = annotatedTypeScanner.findTypes("com.mealtiger.backend.configuration.configs");
+
+        configSet.forEach(config -> {
+            String configPathString = config.getAnnotation(Config.class).configPath();
+            Path configPath = Path.of(configPathString);
+            try {
+                Files.deleteIfExists(configPath);
+                Path backupPath = Path.of("configBackup", configPathString);
+                if (Files.exists(backupPath)) {
+                    Files.move(backupPath, configPath);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        try {
+            Files.deleteIfExists(Path.of("configBackup"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/BitmapAdapterTest.java
@@ -1,8 +1,7 @@
 package com.mealtiger.backend.imageio.adapters;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import com.mealtiger.backend.UnitTestConfigSetup;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +27,16 @@ class BitmapAdapterTest {
     @AfterEach
     void beforeAfterEach() {
         bitmapAdapter = new BitmapAdapter();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/GIFAdapterTest.java
@@ -1,8 +1,7 @@
 package com.mealtiger.backend.imageio.adapters;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import com.mealtiger.backend.UnitTestConfigSetup;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +27,16 @@ class GIFAdapterTest {
     @AfterEach
     void beforeAfterEach() {
         gifAdapter = new GIFAdapter();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/JPEGAdapterTest.java
@@ -1,8 +1,7 @@
 package com.mealtiger.backend.imageio.adapters;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import com.mealtiger.backend.UnitTestConfigSetup;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +27,16 @@ class JPEGAdapterTest {
     @AfterEach
     void beforeAfterEach() {
         jpegAdapter = new JPEGAdapter();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/PNGAdapterTest.java
@@ -1,8 +1,7 @@
 package com.mealtiger.backend.imageio.adapters;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import com.mealtiger.backend.UnitTestConfigSetup;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +27,16 @@ class PNGAdapterTest {
     @AfterEach
     void beforeAfterEach() {
         pngAdapter = new PNGAdapter();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
+++ b/src/test/java/com/mealtiger/backend/imageio/adapters/WebPAdapterTest.java
@@ -1,8 +1,7 @@
 package com.mealtiger.backend.imageio.adapters;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
+import com.mealtiger.backend.UnitTestConfigSetup;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -28,6 +27,16 @@ class WebPAdapterTest {
     @AfterEach
     void beforeAfterEach() {
         webPAdapter = new WebPAdapter();
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
     }
 
     /**

--- a/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
+++ b/src/test/java/com/mealtiger/backend/rest/ImageAPITest.java
@@ -4,6 +4,7 @@ import com.mealtiger.backend.BackendApplication;
 import com.mealtiger.backend.configuration.Configurator;
 import com.mealtiger.backend.database.repository.ImageMetadataRepository;
 import com.mealtiger.backend.rest.controller.ImageIOController;
+import com.mealtiger.backend.rest.error_handling.exceptions.UploadException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -438,7 +439,7 @@ class ImageAPITest {
      * @param uuid UUID of the image.
      * @param userId UserID of the creating user.
      */
-    private void saveImage(File file, String uuid, String userId) throws IOException {
+    private void saveImage(File file, String uuid, String userId) throws IOException, UploadException {
         BufferedImage image = ImageIO.read(file);
         imageIOController.saveImage(image, uuid, userId);
     }

--- a/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
@@ -6,6 +6,7 @@ import com.mealtiger.backend.database.repository.ImageMetadataRepository;
 import com.mealtiger.backend.imageio.adapters.*;
 import com.mealtiger.backend.rest.Helper;
 import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundException;
+import com.mealtiger.backend.rest.error_handling.exceptions.UploadException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -85,7 +86,7 @@ class ImageIOControllerTest {
      * Tests saving images.
      */
     @Test
-    void saveImageTest() throws IOException {
+    void saveImageTest() throws IOException, UploadException {
         when(configurator.getString("Image.servedImageFormats")).thenReturn("png,jpeg,gif,webp,bmp");
         when(configurator.getString("Image.imagePath")).thenReturn("testImages/");
 

--- a/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
+++ b/src/test/java/com/mealtiger/backend/rest/controller/ImageIOControllerTest.java
@@ -1,5 +1,6 @@
 package com.mealtiger.backend.rest.controller;
 
+import com.mealtiger.backend.UnitTestConfigSetup;
 import com.mealtiger.backend.configuration.Configurator;
 import com.mealtiger.backend.database.model.image_metadata.ImageMetadata;
 import com.mealtiger.backend.database.repository.ImageMetadataRepository;
@@ -7,10 +8,7 @@ import com.mealtiger.backend.imageio.adapters.*;
 import com.mealtiger.backend.rest.Helper;
 import com.mealtiger.backend.rest.error_handling.exceptions.EntityNotFoundException;
 import com.mealtiger.backend.rest.error_handling.exceptions.UploadException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.springframework.http.HttpStatus;
@@ -65,6 +63,16 @@ class ImageIOControllerTest {
         }
     }
 
+    @BeforeAll
+    static void beforeAll() {
+        UnitTestConfigSetup.setupConfigs();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UnitTestConfigSetup.teardownConfigs();
+    }
+
     /**
      * Tests reading images.
      */
@@ -77,7 +85,7 @@ class ImageIOControllerTest {
         MockMultipartFile multipartFile = spy(new MockMultipartFile("file", this.getClass().getClassLoader().getResourceAsStream("com/mealtiger/backend/imageio/testImages/DefaultTestImage/TestImage.jpg")));
         BufferedImage image = controller.readImage(multipartFile);
 
-        verify(multipartFile).getInputStream();
+        verify(multipartFile).getBytes();
         assertNotEquals(0, image.getHeight());
         assertNotEquals(0, image.getWidth());
     }


### PR DESCRIPTION
This further improves image conversion speeds by around 33% on machines with multiple threads. The thread count is automatically chosen upon how many threads are available. So, ideally you'd have one thread per image format to encode.